### PR TITLE
fix: replace German "vor" with proper English "ago" in time strings

### DIFF
--- a/cog/user.py
+++ b/cog/user.py
@@ -138,17 +138,17 @@ class User(commands.Cog):
         seconds = int(delta.total_seconds())
 
         if seconds < 60:
-            return f"vor {seconds} seconds"
+            return f"{seconds} seconds ago"
         elif seconds < 3600:
-            return f"vor {seconds // 60} minutes"
+            return f"{seconds // 60} minutes ago"
         elif seconds < 86400:
-            return f"vor {seconds // 3600} hours"
+            return f"{seconds // 3600} hours ago"
         elif seconds < 2592000:
-            return f"vor {seconds // 86400} days"
+            return f"{seconds // 86400} days ago"
         elif seconds < 31536000:
-            return f"vor {seconds // 2592000} months"
+            return f"{seconds // 2592000} months ago"
         else:
-            return f"vor {seconds // 31536000} years"
+            return f"{seconds // 31536000} years ago"
 
 
     @slash_command(name="about", description="Detailed stats about the bot.")


### PR DESCRIPTION
## Summary

The time-ago formatting function in `cog/user.py` uses the German word "vor" (meaning "ago") instead of English in all 6 time-unit branches. This replaces them with proper English "X seconds/minutes/etc. ago" format.

## Changes

- `cog/user.py`: Replaced `f"vor {n} unit"` with `f"{n} unit ago"` for all 6 time units (seconds, minutes, hours, days, months, years).

## Testing

- Verified all 6 occurrences are correctly updated.
- No logic changes, only string format corrections.

Fixes #22